### PR TITLE
master branch에 대한 travis CI 적용

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ jdk:
 
 branches:
   only:
-  - develop
+    - master
+    - develop
 
 # Travis CI 서버의 Home
 cache:


### PR DESCRIPTION
기존 travis 설정에 의하여 devleop branch에 대해서만 travis CI 적용이 가능한 상태였습니다. 이를 변경하여 master branch에 대해서도 동작하도록 수정하였습니다.